### PR TITLE
Add xtt-cpp formula and upgrade xtt

### DIFF
--- a/Formula/xtt-cpp.rb
+++ b/Formula/xtt-cpp.rb
@@ -1,8 +1,8 @@
 class XttCpp < Formula
-  desc "C++ wrappers for the XTT IoT Security Protocol"
+  desc "C++ lib for XTT Trusted Transit Protocol for securing the IoT"
   homepage "https://github.com/xaptum/xtt-cpp"
-  url "https://github.com/xaptum/xtt-cpp/archive/v0.1.0.tar.gz"
-  sha256 "b4a1574ccd0d6b9ffbf2b66a316013147b4f203f03ab96e5c908bedceda9e331"
+  url "https://github.com/xaptum/xtt-cpp/archive/v0.2.0.tar.gz"
+  sha256 "b13e6832cfbe2125a49f71508400cf04028331c35417e3f69bedfa5a9bd17bd5"
 
   depends_on "cmake" => :build
   depends_on "xtt"

--- a/Formula/xtt-cpp.rb
+++ b/Formula/xtt-cpp.rb
@@ -1,0 +1,22 @@
+class XttCpp < Formula
+  desc "C++ wrappers for the XTT IoT Security Protocol"
+  homepage "https://github.com/xaptum/xtt-cpp"
+  url "https://github.com/xaptum/xtt-cpp/archive/v0.1.0.tar.gz"
+  sha256 "b4a1574ccd0d6b9ffbf2b66a316013147b4f203f03ab96e5c908bedceda9e331"
+
+  depends_on "cmake" => :build
+  depends_on "xtt"
+  depends_on "boost"
+
+  def install
+    args = std_cmake_args
+    args << "-DBUILD_EXAMPLES=OFF"
+    args << "-DBUILD_TESTING=OFF"
+
+    mkdir "build" do
+      system "cmake", "-G", "Unix Makefiles", "..", *args
+      system "make"
+      system "make", "install"
+    end
+  end
+end

--- a/Formula/xtt.rb
+++ b/Formula/xtt.rb
@@ -1,12 +1,13 @@
 class Xtt < Formula
   desc "C lib for XTT Trusted Transit Protocol for securing the IoT"
   homepage "https://github.com/xaptum/xtt"
-  url "https://github.com/xaptum/xtt/archive/v0.8.1.tar.gz"
-  sha256 "dd21339bbccfb066b435c8d3f91ffa361fce48815f8558fa9714b10f88786bb3"
+  url "https://github.com/xaptum/xtt/archive/v0.9.1.tar.gz"
+  sha256 "0991e11895b15c08096f53587b444c56647a050b5111fd4095140560452a44a9"
 
   depends_on "cmake" => :build
   depends_on "ecdaa"
   depends_on "libsodium"
+  depends_on "amcl"
   depends_on "xaptum-tpm" => :recommended
 
   def install


### PR DESCRIPTION
Adds xtt-cpp.rb as the xtt-cpp homebrew formula, so that users no longer have to build from source. Updates xtt-cpp to v0.2.0 and xtt to v0.9.1 to be in sync with the xtt library that supports usage of ECDSA.